### PR TITLE
Django RestFramework functionality

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,0 +1,375 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=too-many-lines
+from distutils.version import \
+    StrictVersion  # pylint: disable=no-name-in-module,import-error
+
+from django import get_version
+from django.conf import settings
+from django.contrib.auth.models import Group
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ImproperlyConfigured
+from django.db import models
+from django.db.models.query import QuerySet
+from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
+from django.utils.html import format_html
+
+from jsonfield.fields import JSONField
+from model_utils import Choices
+from notifications import settings as notifications_settings
+from notifications.signals import notify
+from notifications.utils import id2slug
+from swapper import load_model
+
+if StrictVersion(get_version()) >= StrictVersion('1.8.0'):
+    from django.contrib.contenttypes.fields import GenericForeignKey  # noqa
+else:
+    from django.contrib.contenttypes.generic import GenericForeignKey  # noqa
+
+try:
+    # Django >= 1.7
+    from django.urls import reverse, NoReverseMatch
+except ImportError:
+    # Django <= 1.6
+    from django.core.urlresolvers import reverse, NoReverseMatch  # pylint: disable=no-name-in-module,import-error
+
+EXTRA_DATA = notifications_settings.get_config()['USE_JSONFIELD']
+
+
+def is_soft_delete():
+    return notifications_settings.get_config()['SOFT_DELETE']
+
+
+def assert_soft_delete():
+    if not is_soft_delete():
+        # msg = """To use 'deleted' field, please set 'SOFT_DELETE'=True in settings.
+        # Otherwise NotificationQuerySet.unread and NotificationQuerySet.read do NOT filter by 'deleted' field.
+        # """
+        msg = 'REVERTME'
+        raise ImproperlyConfigured(msg)
+
+
+class NotificationQuerySet(models.query.QuerySet):
+    ''' Notification QuerySet '''
+    def unsent(self):
+        return self.filter(emailed=False)
+
+    def sent(self):
+        return self.filter(emailed=True)
+
+    def unread(self, include_deleted=False):
+        """Return only unread items in the current queryset"""
+        if is_soft_delete() and not include_deleted:
+            return self.filter(unread=True, deleted=False)
+
+        # When SOFT_DELETE=False, developers are supposed NOT to touch 'deleted' field.
+        # In this case, to improve query performance, don't filter by 'deleted' field
+        return self.filter(unread=True)
+
+    def read(self, include_deleted=False):
+        """Return only read items in the current queryset"""
+        if is_soft_delete() and not include_deleted:
+            return self.filter(unread=False, deleted=False)
+
+        # When SOFT_DELETE=False, developers are supposed NOT to touch 'deleted' field.
+        # In this case, to improve query performance, don't filter by 'deleted' field
+        return self.filter(unread=False)
+
+    def mark_all_as_read(self, recipient=None):
+        """Mark as read any unread messages in the current queryset.
+
+        Optionally, filter these by recipient first.
+        """
+        # We want to filter out read ones, as later we will store
+        # the time they were marked as read.
+        qset = self.unread(True)
+        if recipient:
+            qset = qset.filter(recipient=recipient)
+
+        return qset.update(unread=False)
+
+    def mark_all_as_unread(self, recipient=None):
+        """Mark as unread any read messages in the current queryset.
+
+        Optionally, filter these by recipient first.
+        """
+        qset = self.read(True)
+
+        if recipient:
+            qset = qset.filter(recipient=recipient)
+
+        return qset.update(unread=True)
+
+    def deleted(self):
+        """Return only deleted items in the current queryset"""
+        assert_soft_delete()
+        return self.filter(deleted=True)
+
+    def active(self):
+        """Return only active(un-deleted) items in the current queryset"""
+        assert_soft_delete()
+        return self.filter(deleted=False)
+
+    def mark_all_as_deleted(self, recipient=None):
+        """Mark current queryset as deleted.
+        Optionally, filter by recipient first.
+        """
+        assert_soft_delete()
+        qset = self.active()
+        if recipient:
+            qset = qset.filter(recipient=recipient)
+
+        return qset.update(deleted=True)
+
+    def mark_all_as_active(self, recipient=None):
+        """Mark current queryset as active(un-deleted).
+        Optionally, filter by recipient first.
+        """
+        assert_soft_delete()
+        qset = self.deleted()
+        if recipient:
+            qset = qset.filter(recipient=recipient)
+
+        return qset.update(deleted=False)
+
+    def mark_as_unsent(self, recipient=None):
+        qset = self.sent()
+        if recipient:
+            qset = qset.filter(recipient=recipient)
+        return qset.update(emailed=False)
+
+    def mark_as_sent(self, recipient=None):
+        qset = self.unsent()
+        if recipient:
+            qset = qset.filter(recipient=recipient)
+        return qset.update(emailed=True)
+
+
+class AbstractNotification(models.Model):
+    """
+    Action model describing the actor acting out a verb (on an optional
+    target).
+    Nomenclature based on http://activitystrea.ms/specs/atom/1.0/
+
+    Generalized Format::
+
+        <actor> <verb> <time>
+        <actor> <verb> <target> <time>
+        <actor> <verb> <action_object> <target> <time>
+
+    Examples::
+
+        <justquick> <reached level 60> <1 minute ago>
+        <brosner> <commented on> <pinax/pinax> <2 hours ago>
+        <washingtontimes> <started follow> <justquick> <8 minutes ago>
+        <mitsuhiko> <closed> <issue 70> on <mitsuhiko/flask> <about 2 hours ago>
+
+    Unicode Representation::
+
+        justquick reached level 60 1 minute ago
+        mitsuhiko closed issue 70 on mitsuhiko/flask 3 hours ago
+
+    HTML Representation::
+
+        <a href="http://oebfare.com/">brosner</a> commented on <a href="http://github.com/pinax/pinax">pinax/pinax</a> 2 hours ago # noqa
+
+    """
+    LEVELS = Choices('success', 'info', 'warning', 'error')
+    level = models.CharField(_('level'), choices=LEVELS, default=LEVELS.info, max_length=20)
+
+    recipient = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name='notifications',
+        verbose_name=_('recipient'),
+        blank=False,
+    )
+    unread = models.BooleanField(_('unread'), default=True, blank=False, db_index=True)
+
+    actor_content_type = models.ForeignKey(
+        ContentType,
+        on_delete=models.CASCADE,
+        related_name='notify_actor',
+        verbose_name=_('actor content type')
+    )
+    actor_object_id = models.CharField(_('actor object id'), max_length=255)
+    actor = GenericForeignKey('actor_content_type', 'actor_object_id')
+    actor.short_description = _('actor')
+
+    verb = models.CharField(_('verb'), max_length=255)
+    description = models.TextField(_('description'), blank=True, null=True)
+
+    target_content_type = models.ForeignKey(
+        ContentType,
+        on_delete=models.CASCADE,
+        related_name='notify_target',
+        verbose_name=_('target content type'),
+        blank=True,
+        null=True
+    )
+    target_object_id = models.CharField(_('target object id'), max_length=255, blank=True, null=True)
+    target = GenericForeignKey('target_content_type', 'target_object_id')
+    target.short_description = _('target')
+
+    action_object_content_type = models.ForeignKey(
+        ContentType,
+        on_delete=models.CASCADE,
+        related_name='notify_action_object',
+        verbose_name=_('action object content type'),
+        blank=True,
+        null=True
+    )
+    action_object_object_id = models.CharField(_('action object object id'), max_length=255, blank=True, null=True)
+    action_object = GenericForeignKey('action_object_content_type', 'action_object_object_id')
+    action_object.short_description = _('action object')
+
+    timestamp = models.DateTimeField(_('timestamp'), default=timezone.now, db_index=True)
+
+    public = models.BooleanField(_('public'), default=True, db_index=True)
+    deleted = models.BooleanField(_('deleted'), default=False, db_index=True)
+    emailed = models.BooleanField(_('emailed'), default=False, db_index=True)
+
+    data = JSONField(_('data'), blank=True, null=True)
+
+    objects = NotificationQuerySet.as_manager()
+
+    class Meta:
+        abstract = True
+        ordering = ('-timestamp',)
+        # speed up notifications count query
+        index_together = ('recipient', 'unread')
+        verbose_name = _('Notification')
+        verbose_name_plural = _('Notifications')
+
+    def __str__(self):
+        ctx = {
+            'actor': self.actor,
+            'verb': self.verb,
+            'action_object': self.action_object,
+            'target': self.target,
+            'timesince': self.timesince()
+        }
+        if self.target:
+            if self.action_object:
+                return _('%(actor)s %(verb)s %(action_object)s on %(target)s %(timesince)s ago') % ctx
+            return _('%(actor)s %(verb)s %(target)s %(timesince)s ago') % ctx
+        if self.action_object:
+            return _('%(actor)s %(verb)s %(action_object)s %(timesince)s ago') % ctx
+        return _('%(actor)s %(verb)s %(timesince)s ago') % ctx
+
+    def timesince(self, now=None):
+        """
+        Shortcut for the ``django.utils.timesince.timesince`` function of the
+        current timestamp.
+        """
+        from django.utils.timesince import timesince as timesince_
+        return timesince_(self.timestamp, now)
+
+    @property
+    def slug(self):
+        return id2slug(self.id)
+
+    def mark_as_read(self):
+        if self.unread:
+            self.unread = False
+            self.save()
+
+    def mark_as_unread(self):
+        if not self.unread:
+            self.unread = True
+            self.save()
+
+    def actor_object_url(self):
+        try:
+            url = reverse("admin:{0}_{1}_change".format(self.actor_content_type.app_label,
+                                                        self.actor_content_type.model),
+                          args=(self.actor_object_id,))
+            return format_html("<a href='{url}'>{id}</a>", url=url, id=self.actor_object_id)
+        except NoReverseMatch:
+            return self.actor_object_id
+
+    def action_object_url(self):
+        try:
+            url = reverse("admin:{0}_{1}_change".format(self.action_object_content_type.app_label,
+                                                        self.action_content_type.model),
+                          args=(self.action_object_id,))
+            return format_html("<a href='{url}'>{id}</a>", url=url, id=self.action_object_object_id)
+        except NoReverseMatch:
+            return self.action_object_object_id
+
+    def target_object_url(self):
+        try:
+            url = reverse("admin:{0}_{1}_change".format(self.target_content_type.app_label,
+                                                        self.target_content_type.model),
+                          args=(self.target_object_id,))
+            return format_html("<a href='{url}'>{id}</a>", url=url, id=self.target_object_id)
+        except NoReverseMatch:
+            return self.target_object_id
+
+
+def notify_handler(verb, **kwargs):
+    """
+    Handler function to create Notification instance upon action signal call.
+    """
+    # Pull the options out of kwargs
+    kwargs.pop('signal', None)
+    recipient = kwargs.pop('recipient')
+    actor = kwargs.pop('sender')
+    optional_objs = [
+        (kwargs.pop(opt, None), opt)
+        for opt in ('target', 'action_object')
+    ]
+    public = bool(kwargs.pop('public', True))
+    description = kwargs.pop('description', None)
+    timestamp = kwargs.pop('timestamp', timezone.now())
+    Notification = load_model('notifications', 'Notification')
+    level = kwargs.pop('level', Notification.LEVELS.info)
+    actor_for_concrete_model = kwargs.pop('actor_for_concrete_model', True)
+    data = kwargs.pop('data', None)
+
+    # Check if User or Group
+    if isinstance(recipient, Group):
+        recipients = recipient.user_set.all()
+    elif isinstance(recipient, (QuerySet, list)):
+        recipients = recipient
+    else:
+        recipients = [recipient]
+
+    new_notifications = []
+
+    for recipient in recipients:
+        newnotify = Notification(
+            recipient=recipient,
+            actor_content_type=ContentType.objects.get_for_model(actor, for_concrete_model=actor_for_concrete_model),
+            actor_object_id=actor.pk,
+            verb=str(verb),
+            public=public,
+            description=description,
+            timestamp=timestamp,
+            level=level,
+            data=data,
+        )
+
+        # Set optional objects
+        for obj, opt in optional_objs:
+            if obj is not None:
+                for_concrete_model = kwargs.pop(f'{opt}_for_concrete_model', True)
+                setattr(newnotify, '%s_object_id' % opt, obj.pk)
+                setattr(newnotify, '%s_content_type' % opt,
+                        ContentType.objects.get_for_model(obj, for_concrete_model=for_concrete_model))
+
+        if kwargs and EXTRA_DATA:
+            # set kwargs as model column if available
+            for key in list(kwargs.keys()):
+                if hasattr(newnotify, key):
+                    setattr(newnotify, key, kwargs.pop(key))
+            newnotify.data = kwargs
+
+        newnotify.save()
+        new_notifications.append(newnotify)
+
+    return new_notifications
+
+
+# connect the signal
+notify.connect(notify_handler, dispatch_uid='notifications.models.notification')

--- a/serializers.py
+++ b/serializers.py
@@ -1,0 +1,20 @@
+from rest_framework import serializers
+from notifications.models import Notification
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+class PublicUserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ['id', 'username',]
+
+class NotificationSerializer(serializers.ModelSerializer):
+    recipient = PublicUserSerializer(read_only=True)
+    unread = serializers.BooleanField(read_only=True)
+
+
+    class Meta:
+        model = Notification
+        fields = "__all__"

--- a/urls.py
+++ b/urls.py
@@ -1,0 +1,33 @@
+''' Django notification urls file '''
+# -*- coding: utf-8 -*-
+from distutils.version import StrictVersion  # pylint: disable=no-name-in-module,import-error
+
+from django import get_version
+from django.urls import include
+from rest_framework import routers
+
+from . import views
+
+if StrictVersion(get_version()) >= StrictVersion('2.0'):
+    from django.urls import re_path as pattern
+else:
+    from django.conf.urls import url as pattern
+
+router = routers.DefaultRouter()
+router.register(r'notifications', views.NotificationsViewSet, basename='notifications')
+
+urlpatterns = [
+    pattern(r'^api/', include(router.urls), name='api'),
+    pattern(r'^$', views.AllNotificationsList.as_view(), name='all'),
+    pattern(r'^unread/$', views.UnreadNotificationsList.as_view(), name='unread'),
+    pattern(r'^mark-all-as-read/$', views.mark_all_as_read, name='mark_all_as_read'),
+    pattern(r'^mark-as-read/(?P<slug>\d+)/$', views.mark_as_read, name='mark_as_read'),
+    pattern(r'^mark-as-unread/(?P<slug>\d+)/$', views.mark_as_unread, name='mark_as_unread'),
+    pattern(r'^delete/(?P<slug>\d+)/$', views.delete, name='delete'),
+    pattern(r'^api/unread_count/$', views.live_unread_notification_count, name='live_unread_notification_count'),
+    pattern(r'^api/all_count/$', views.live_all_notification_count, name='live_all_notification_count'),
+    pattern(r'^api/unread_list/$', views.live_unread_notification_list, name='live_unread_notification_list'),
+    pattern(r'^api/all_list/', views.live_all_notification_list, name='live_all_notification_list'),
+]
+
+app_name = 'notifications'

--- a/views.py
+++ b/views.py
@@ -1,0 +1,313 @@
+# -*- coding: utf-8 -*-
+''' Django Notifications example views '''
+from distutils.version import \
+    StrictVersion  # pylint: disable=no-name-in-module,import-error
+
+from django import get_version
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import get_object_or_404, redirect
+from django.utils.decorators import method_decorator
+from django.utils.encoding import iri_to_uri
+from django.utils.http import url_has_allowed_host_and_scheme
+from django.views.decorators.cache import never_cache
+from django.views.generic import ListView
+from swapper import load_model
+
+
+from rest_framework import permissions, status, pagination
+from rest_framework.response import Response
+from rest_framework.decorators import action
+from notifications.serializers import NotificationSerializer
+from notifications.viewsets import NotificationsBaseViewSet
+
+from notifications import settings as notification_settings
+from notifications.helpers import get_notification_list
+from notifications.utils import slug2id
+
+Notification = load_model('notifications', 'Notification')
+
+if StrictVersion(get_version()) >= StrictVersion('1.7.0'):
+    from django.http import JsonResponse  # noqa
+else:
+    # Django 1.6 doesn't have a proper JsonResponse
+    import json
+
+    from django.http import HttpResponse  # noqa
+
+    def date_handler(obj):
+        return obj.isoformat() if hasattr(obj, 'isoformat') else obj
+
+    def JsonResponse(data):  # noqa
+        return HttpResponse(
+            json.dumps(data, default=date_handler),
+            content_type="application/json")
+
+
+class NotificationViewList(ListView):
+    template_name = 'notifications/list.html'
+    context_object_name = 'notifications'
+    paginate_by = notification_settings.get_config()['PAGINATE_BY']
+
+    @method_decorator(login_required)
+    def dispatch(self, request, *args, **kwargs):
+        return super(NotificationViewList, self).dispatch(
+            request, *args, **kwargs)
+
+
+class AllNotificationsList(NotificationViewList):
+    """
+    Index page for authenticated user
+    """
+
+    def get_queryset(self):
+        if notification_settings.get_config()['SOFT_DELETE']:
+            qset = self.request.user.notifications.active()
+        else:
+            qset = self.request.user.notifications.all()
+        return qset
+
+
+class UnreadNotificationsList(NotificationViewList):
+
+    def get_queryset(self):
+        return self.request.user.notifications.unread()
+
+
+@login_required
+def mark_all_as_read(request):
+    request.user.notifications.mark_all_as_read()
+
+    _next = request.GET.get('next')
+
+    if _next and url_has_allowed_host_and_scheme(_next, settings.ALLOWED_HOSTS):
+        return redirect(iri_to_uri(_next))
+    return redirect('notifications:unread')
+
+
+@login_required
+def mark_as_read(request, slug=None):
+    notification_id = slug2id(slug)
+
+    notification = get_object_or_404(
+        Notification, recipient=request.user, id=notification_id)
+    notification.mark_as_read()
+
+    _next = request.GET.get('next')
+
+    if _next and url_has_allowed_host_and_scheme(_next, settings.ALLOWED_HOSTS):
+        return redirect(iri_to_uri(_next))
+
+    return redirect('notifications:unread')
+
+
+@login_required
+def mark_as_unread(request, slug=None):
+    notification_id = slug2id(slug)
+
+    notification = get_object_or_404(
+        Notification, recipient=request.user, id=notification_id)
+    notification.mark_as_unread()
+
+    _next = request.GET.get('next')
+
+    if _next and url_has_allowed_host_and_scheme(_next, settings.ALLOWED_HOSTS):
+        return redirect(iri_to_uri(_next))
+
+    return redirect('notifications:unread')
+
+
+@login_required
+def delete(request, slug=None):
+    notification_id = slug2id(slug)
+
+    notification = get_object_or_404(
+        Notification, recipient=request.user, id=notification_id)
+
+    if notification_settings.get_config()['SOFT_DELETE']:
+        notification.deleted = True
+        notification.save()
+    else:
+        notification.delete()
+
+    _next = request.GET.get('next')
+
+    if _next and url_has_allowed_host_and_scheme(_next, settings.ALLOWED_HOSTS):
+        return redirect(iri_to_uri(_next))
+
+    return redirect('notifications:all')
+
+
+@never_cache
+def live_unread_notification_count(request):
+    try:
+        user_is_authenticated = request.user.is_authenticated()
+    except TypeError:  # Django >= 1.11
+        user_is_authenticated = request.user.is_authenticated
+
+    if not user_is_authenticated:
+        data = {
+            'unread_count': 0
+        }
+    else:
+        data = {
+            'unread_count': request.user.notifications.unread().count(),
+        }
+    return JsonResponse(data)
+
+
+@never_cache
+def live_unread_notification_list(request):
+    ''' Return a json with a unread notification list '''
+    try:
+        user_is_authenticated = request.user.is_authenticated()
+    except TypeError:  # Django >= 1.11
+        user_is_authenticated = request.user.is_authenticated
+
+    if not user_is_authenticated:
+        data = {
+            'unread_count': 0,
+            'unread_list': []
+        }
+        return JsonResponse(data)
+
+    unread_list = get_notification_list(request, 'unread')
+
+    data = {
+        'unread_count': request.user.notifications.unread().count(),
+        'unread_list': unread_list
+    }
+    return JsonResponse(data)
+
+
+@never_cache
+def live_all_notification_list(request):
+    ''' Return a json with a unread notification list '''
+    try:
+        user_is_authenticated = request.user.is_authenticated()
+    except TypeError:  # Django >= 1.11
+        user_is_authenticated = request.user.is_authenticated
+
+    if not user_is_authenticated:
+        data = {
+            'all_count': 0,
+            'all_list': []
+        }
+        return JsonResponse(data)
+
+    all_list = get_notification_list(request)
+
+    data = {
+        'all_count': request.user.notifications.count(),
+        'all_list': all_list
+    }
+    return JsonResponse(data)
+
+
+def live_all_notification_count(request):
+    try:
+        user_is_authenticated = request.user.is_authenticated()
+    except TypeError:  # Django >= 1.11
+        user_is_authenticated = request.user.is_authenticated
+
+    if not user_is_authenticated:
+        data = {
+            'all_count': 0
+        }
+    else:
+        data = {
+            'all_count': request.user.notifications.count(),
+        }
+    return JsonResponse(data)
+
+
+class NotificationsViewSet(NotificationsBaseViewSet):
+
+    """
+    This viewset that provides the following actions `retrieve()`, `update()`, `destroy()` and `list()`.
+    `retrieve()`: is used to retrieve the object related to the user and mark it as read
+    `update()`: is used to update the object related to the user by mark it as unread
+    `destroy()`: is used to deleting object related to the user depending on the settings if settings.get_config()['SOFT_DELETE']
+    `list()`: is used to retrieve all the objects related to the user
+    `access_all()`: is used to retrieve all the objects related to the user and mark them as read with a post request
+    `access_all()`: is used to retrieve all the objects related to the user and mark them as unread with a put request
+    `access_all()`: is used to retrieve all the objects related to the user and delete them,\n
+    depending on the settings if settings.get_config()['SOFT_DELETE'] with a delete request
+    `unread_notification_list()`: is used to retrieve all the objects related to the user that are not read
+    `unread_count()`: is used to retrieve the number objects that are not read and related to the user
+    `notifications_count()`: is used to retrieve the number objects that are  related to the user
+    """
+
+    serializer_class = NotificationSerializer
+    permission_classes = (permissions.IsAuthenticated,)
+    pagination_class = (pagination.PageNumberPagination)
+    lookup_field = 'id'
+
+    
+    def perform_destroy(self,instance):
+        if settings.get_config()['SOFT_DELETE']:
+            instance.deleted = True
+            instance.save()
+        else:
+            instance.delete()
+
+    @action(["get"], detail=False)
+    def unread_count(self, request, *args, **kwargs):
+        data = {
+            'unread_count': request.user.notifications.unread().count(),
+        }
+        return Response(data, status=status.HTTP_200_OK)
+
+    @action(["get"], detail=False)
+    def notifications_count(self, request, *args, **kwargs):
+        data = {
+            'count': request.user.notifications.active().count(),
+        }
+        return Response(data, status=status.HTTP_200_OK)
+    
+    @action(["get"], detail=False)
+    def unread_notification_list(self, request, *args, **kwargs):
+        queryset = request.user.notifications.unread().filter(deleted=False).order_by("-timestamp")
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+    
+    @action(["post", "put", "delete"], detail=False)
+    def access_all(self, request, *args, **kwargs):
+        if request.method == "POST":
+            request.user.notifications.active().mark_all_as_read()
+            return Response(status=status.HTTP_200_OK)
+        elif request.method == "PUT":
+            request.user.notifications.active().mark_all_as_unread()
+            return Response(status=status.HTTP_200_OK)
+        elif request.method == "DELETE":
+            request.user.notifications.active().mark_all_as_deleted()
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        
+
+        
+    def retrieve(self, request, *args, **kwargs):
+        notification = self.get_object()
+        notification.mark_as_read()
+        serilaizer = self.serializer_class(notification)
+        return Response(serilaizer.data, status=status.HTTP_200_OK)
+
+    def update(self, request, *args, **kwargs):
+        notification = self.get_object()
+        notification.mark_as_unread()
+        serilaizer = self.serializer_class(notification)
+        return Response(serilaizer.data, status=status.HTTP_200_OK)
+    
+    def destroy(self, request, *args, **kwargs):
+        notification = self.get_object()
+        self.perform_destroy(notification)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+    def get_queryset(self):
+        return self.request.user.notifications.active().order_by("-timestamp")

--- a/viewsets.py
+++ b/viewsets.py
@@ -1,0 +1,13 @@
+from rest_framework import mixins, viewsets
+
+
+class NotificationsBaseViewSet(mixins.RetrieveModelMixin,
+                           mixins.UpdateModelMixin,
+                            mixins.DestroyModelMixin,
+                           mixins.ListModelMixin,
+                           viewsets.GenericViewSet):
+    """
+    A viewset that provides default `retrieve()`, `update()`,
+    `partial_update()`, `destroy()` and `list()` actions.
+    """
+    pass


### PR DESCRIPTION
Setting page size for the ViewSet in the settings file Dependency would be drango rest_framework

INSTALLED_APPS = (
'django.contrib.auth',
...
'rest_framework',
'notifications',
...
)


REST_FRAMEWORK = {
    ......................

    'DEFAULT_AUTHENTICATION_CLASSES': (
        'rest_framework.authentication.BasicAuthentication',
        'rest_framework.authentication.SessionAuthentication',
    ),
    'PAGE_SIZE': 10,
    .....................

}

# base/models.py

-On base/models.py added data field a key word argument and also on newnotify when creating the object. e.g 
serializer = MyObjectSerializer(instance)
# take into consideration fields that can be serialized into JSONField copy = serializer.data.copy()

notify.send(
	instance
	recipient=users, 
	verb='Its a verb',
	action_object=instance,
	data = copy,
        description='it a notification',
)

-I would recommend using a copy instead of the original to avoid transaction problems especially if you are using a signal in particular pre_save

# serializer.py
-A Serializer included at serializer.py for the notification and the user serializers. ModelSerializer is only used for the pre defined fields.

#viewset.py
-A Viewset included at viewset.py for the base viewset.  -The create action is not available since notify_handler will be used for that. 

#views.py @NotificationsViewSet
-The update action on marks the notification as unread and returns the object while retrieve marks the notification a read and returns the object, and the destroy method either marks the notification deleted or deletes the notification depending on the settings if soft delete is enabled -Additionally added the viewset on the views file with some actions

# urls.py
-And finally registered the viewset using the router from rest_framework

Your projects is awesome I wanted to contribute